### PR TITLE
Add 'more...' links after the description and add an anchor to metrics and attributes

### DIFF
--- a/mara_schema/attribute.py
+++ b/mara_schema/attribute.py
@@ -25,7 +25,10 @@ class Attribute():
 
     def __init__(self, name: str, description: str, column_name: str,
                  accessible_via_entity_link: bool, type: 'Type' = None, high_cardinality: bool = False,
-                 personal_data: bool = False, important_field: bool = False) -> None:
+                 personal_data: bool = False,
+                 important_field: bool = False,
+                 more_url: typing.Optional[str] = None,
+                 ) -> None:
         """See documentation of function Entity.add_attribute"""
         self.name = name
         self.description = description
@@ -35,6 +38,7 @@ class Attribute():
         self.personal_data = personal_data
         self.important_field = important_field
         self.accessible_via_entity_link = accessible_via_entity_link
+        self.more_url = more_url
 
     def __repr__(self) -> str:
         return f'<Attribute "{self.name}">'

--- a/mara_schema/data_set.py
+++ b/mara_schema/data_set.py
@@ -29,7 +29,9 @@ class DataSet():
 
     def add_simple_metric(self, name: str, description: str, column_name: str, aggregation: Aggregation,
                           important_field: bool = False,
-                          number_format: NumberFormat = NumberFormat.STANDARD):
+                          number_format: NumberFormat = NumberFormat.STANDARD,
+                          more_url: typing.Optional[str] = None,
+                          ):
         """
         Add a metric that is computed as a direct aggregation on a entity table column
 
@@ -40,6 +42,7 @@ class DataSet():
             aggregation: The aggregation method to use
             important_field: It refers to key business metrics.
             number_format: The way to format a string. Defaults to NumberFormat.STANDARD.
+            more_url: URL (as string) which should be appended as a `more...` link in the UI.
         """
         if name in self.metrics:
             raise ValueError(f'Metric "{name}" already exists in data set "{self.name}"')
@@ -51,10 +54,14 @@ class DataSet():
             column_name=column_name,
             aggregation=aggregation,
             important_field=important_field,
-            number_format=number_format)
+            number_format=number_format,
+            more_url=more_url,
+        )
 
     def add_composed_metric(self, name: str, description: str, formula: str, important_field: bool = False,
-                            number_format: NumberFormat = NumberFormat.STANDARD):
+                            number_format: NumberFormat = NumberFormat.STANDARD,
+                            more_url: typing.Optional[str] = None,
+                            ):
         """
         Add a metric that is based on a list of simple metrics.
 
@@ -64,6 +71,7 @@ class DataSet():
             formula: How to compute the metric. Examples: [Metric A] + [Metric B],  [Metric A] / ([Metric B] + [Metric C])
             important_field: It refers to key business metrics.
             number_format: The way to format a string. Defaults to NumberFormat.STANDARD.
+            more_url: URL (as string) which should be appended as a `more...` link in the UI.
         """
         if name in self.metrics:
             raise ValueError(f'Metric "{name}" already exists in data set "{self.name}"')
@@ -86,7 +94,9 @@ class DataSet():
                                             parent_metrics=parent_metrics,
                                             formula_template='{}'.join(formula_split[0::2]),
                                             important_field=important_field,
-                                            number_format=number_format)
+                                            number_format=number_format,
+                                            more_url=more_url,
+                                            )
 
     _PathSpec = typing.TypeVar('_PathSpec', typing.Sequence[typing.Union[str, typing.Tuple[str, str]]], bytes)
 
@@ -180,7 +190,7 @@ class DataSet():
                 path = current_path + (entity_link,)
 
                 if (entity_link not in current_path  # check for circles in path
-                        and (path not in self.excluded_paths)  # explicitly excluded paths
+                    and (path not in self.excluded_paths)  # explicitly excluded paths
                 ):
                     _append_path_including_subpaths(paths, path)
                     traverse_graph(entity_link.target_entity, path)
@@ -211,10 +221,10 @@ class DataSet():
             for attribute in entity.attributes:
                 if ((path in self.included_attributes and attribute in self.included_attributes[path])
                     or (path not in self.included_attributes)) \
-                        and ((path in self.excluded_attributes and attribute not in self.excluded_attributes[path])
-                             or (path not in self.excluded_attributes)) \
-                        and attribute.accessible_via_entity_link and (
-                        include_personal_data or not attribute.personal_data):
+                    and ((path in self.excluded_attributes and attribute not in self.excluded_attributes[path])
+                         or (path not in self.excluded_attributes)) \
+                    and attribute.accessible_via_entity_link and (
+                    include_personal_data or not attribute.personal_data):
                     result[path][attribute.prefixed_name(path)] = attribute
         return result
 

--- a/mara_schema/entity.py
+++ b/mara_schema/entity.py
@@ -1,3 +1,5 @@
+import typing
+
 from .attribute import Attribute, Type
 
 
@@ -32,7 +34,9 @@ class Entity():
 
     def add_attribute(self, name: str, description: str, column_name: str = None, type: Type = None,
                       high_cardinality: bool = False, personal_data: bool = False, important_field: bool = False,
-                      accessible_via_entity_link: bool = True) -> None:
+                      accessible_via_entity_link: bool = True,
+                      more_url: typing.Optional[str] = None,
+                      ) -> None:
         """
         Adds a property based on a column in the underlying dimensional table to the entity
 
@@ -46,7 +50,8 @@ class Entity():
             personal_data: It refers to person related data, e.g. "Email address", "Name".
             important_field: A field that highlights the the data set. Shown by default in overviews
             accessible_via_entity_link: If False, then this attribute is excluded from data sets that are not
-                     based on this entity
+                     based on this entity.
+            more_url: URL (as string) which should be appended as a `more...` link in the UI.
         """
         self.attributes.append(
             Attribute(
@@ -57,7 +62,8 @@ class Entity():
                 type=type,
                 high_cardinality=high_cardinality,
                 personal_data=personal_data,
-                important_field=important_field
+                important_field=important_field,
+                more_url=more_url,
             ))
 
     def link_entity(self, target_entity: 'Entity', fk_column: str = None,
@@ -118,7 +124,7 @@ class Entity():
 
 class EntityLink():
     def __init__(self, target_entity: Entity, prefix: str,
-                 description: str= None, fk_column: str = None) -> None:
+                 description: str = None, fk_column: str = None) -> None:
         """
         A link from an entity to another entity, corresponds to a foreign key relationship
 

--- a/mara_schema/metric.py
+++ b/mara_schema/metric.py
@@ -1,6 +1,8 @@
 import abc
 import enum
 
+import typing
+
 
 class Aggregation(enum.EnumMeta):
     """Aggregation methods for metrics"""
@@ -42,7 +44,8 @@ class Metric(abc.ABC):
 class SimpleMetric(Metric):
     def __init__(self, name: str, description: str, data_set: 'DataSet',
                  column_name: str, aggregation: Aggregation, important_field: bool = False,
-                 number_format: NumberFormat = NumberFormat.STANDARD):
+                 number_format: NumberFormat = NumberFormat.STANDARD,
+                 more_url: typing.Optional[str] = None):
         """
         A metric that is computed as a direct aggregation on a entity table column
         Args:
@@ -59,6 +62,7 @@ class SimpleMetric(Metric):
         self.aggregation = aggregation
         self.important_field = important_field
         self.number_format = number_format
+        self.more_url = more_url
 
     def __repr__(self) -> str:
         return f'<Metric "{self.name}": {self.display_formula()})>'
@@ -70,7 +74,8 @@ class SimpleMetric(Metric):
 class ComposedMetric(Metric):
     def __init__(self, name: str, description: str, data_set: 'DataSet',
                  parent_metrics: [Metric], formula_template: str, important_field: bool = False,
-                 number_format: NumberFormat = NumberFormat.STANDARD) -> None:
+                 number_format: NumberFormat = NumberFormat.STANDARD,
+                 more_url: typing.Optional[str] = None) -> None:
         """
         A metric that is based on a list of simple metrics.
         Args:
@@ -88,6 +93,7 @@ class ComposedMetric(Metric):
         self.formula_template = formula_template
         self.important_field = important_field
         self.number_format = number_format
+        self.more_url = more_url
 
     def __repr__(self) -> str:
         return f'<ComposedMetric "{self.name}": {self.display_formula()}>'

--- a/mara_schema/ui/graph.py
+++ b/mara_schema/ui/graph.py
@@ -11,12 +11,12 @@ edge_arrow_size_ = '0.7'
 
 
 def overview_graph():
-    from ..config import data_sets
+    from .. import config
     from .views import data_set_url
 
     all_entities = set()
 
-    for data_set in data_sets():
+    for data_set in config.data_sets():
         all_entities.update(data_set.entity.connected_entities())
 
     graph = graphviz.Digraph(engine='neato', graph_attr={})

--- a/mara_schema/ui/static/mara-schema.css
+++ b/mara_schema/ui/static/mara-schema.css
@@ -1,0 +1,18 @@
+/*
+As of 2021-01-25, supported in Chrome, Firefoy, Edge, but not Safari and doesn't need any extra css
+classes on the anchor
+https://css-tricks.com/fixed-headers-on-page-links-and-overlapping-content-oh-my/
+*/
+html {
+  scroll-padding-top: 90px; /* height of sticky header + head of table */
+}
+
+/* For styling a trailing <a hred="#id" id="#id">¶</a> so it's light grey but gets the blue + underline on hover */
+html a.anchor-link-sign {
+    color: #bfbfbf;
+}
+
+html a.anchor-link-sign:hover {
+    cursor: pointer;
+    color: #0275d8;
+}

--- a/mara_schema/ui/views.py
+++ b/mara_schema/ui/views.py
@@ -1,9 +1,11 @@
 """Documentation of data sets and entities"""
 
 import functools
+import re
 from html import escape
 
 import flask
+import unicodedata
 from mara_page import acl, navigation, response, bootstrap, _, html
 
 from ..data_set import DataSet
@@ -18,6 +20,28 @@ acl_resource_schema = acl.AclResource(name='Schema')
 
 def data_set_url(data_set: DataSet) -> str:
     return flask.url_for('mara_schema.data_set_page', id=data_set.id())
+
+
+_slugify_strip_re = re.compile(r'[^\w\s-]')
+_slugify_hyphenate_re = re.compile(r'[-\s]+')
+
+
+# from https://github.com/django/django/blob/0382ecfe020b4c51b4c01e4e9a21892771e66941/django/utils/text.py
+# Under BSD license
+def slugify(value, allow_unicode=False):
+    """
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
+    dashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+    """
+    value = str(value)
+    if allow_unicode:
+        value = unicodedata.normalize('NFKC', value)
+    else:
+        value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
+    value = re.sub(_slugify_strip_re, '', value.lower())
+    return re.sub(_slugify_hyphenate_re, '-', value).strip('-_')
 
 
 def schema_navigation_entry() -> navigation.NavigationEntry:
@@ -95,12 +119,40 @@ def data_set_page(id: str) -> response.Response:
                     [' &nbsp;&nbsp;', _.i[path[-1].description]] if path[-1].description else ''
                 ]])
             for prefixed_name, attribute in attributes.items():
-                rows.append(_.tr[_.td[escape(prefixed_name)],
-                                 _.td[[_.i[escape(attribute.description)]] +
-                                      ([' (', _.a(href=attribute.more_url)['more...'], ')']
-                                       if attribute.more_url else [])],
-                                 _.td[_.tt[escape(
-                                     f'{path[-1].target_entity.table_name + "." if path else ""}{attribute.column_name}')]]])
+                attribute_link_id = slugify(f'attribute {path[-1].target_entity.name if path else ""} {attribute.name}')
+                rows.append(_.tr(id=attribute_link_id)[
+                                _.td[
+                                    escape(prefixed_name),
+                                    ' ',
+                                    _.a(class_='anchor-link-sign',
+                                        href=f'#{attribute_link_id}')['¶'],
+
+                                ],
+                                _.td[[_.i[escape(attribute.description)]] +
+                                     ([' (', _.a(href=attribute.more_url)['more...'], ')']
+                                      if attribute.more_url else [])],
+                                _.td[_.tt[escape(
+                                    f'{path[-1].target_entity.table_name + "." if path else ""}{attribute.column_name}')]]])
+        return rows
+
+    def metrics_rows(data_set: DataSet) -> []:
+        rows = []
+        for metric in data_set.metrics.values():
+            metric_link_id = slugify(f'metric {metric.name}')
+
+            rows.append([_.tr(id=metric_link_id)[
+                            _.td[
+                                escape(metric.name),
+                                ' ',
+                                _.a(class_='anchor-link-sign',
+                                    href=f'#{metric_link_id}')['¶'],
+
+                            ],
+                            _.td[[_.i[escape(metric.description)]] +
+                                 ([' (', _.a(href=metric.more_url)['more...'], ')'] if metric.more_url else [])
+                                 ],
+                            _.td[_.code[escape(metric.display_formula())]]
+                        ]])
         return rows
 
     return response.Response(
@@ -117,13 +169,8 @@ def data_set_page(id: str) -> response.Response:
                     html.asynchronous_content(flask.url_for('mara_schema.metrics_graph', id=data_set.id())),
                     bootstrap.table(
                         ['Name', 'Description', 'Computation'],
-                        [[_.tr[
-                              _.td[escape(metric.name)],
-                              _.td[[_.i[escape(metric.description)]] +
-                                   ([' (', _.a(href=metric.more_url)['more...'], ')'] if metric.more_url else [])
-                                   ],
-                              _.td[_.code[escape(metric.display_formula())]]
-                          ] for metric in data_set.metrics.values()]]),
+                        metrics_rows(data_set)
+                    ),
                 ]),
             bootstrap.card(
                 header_left='Attributes',
@@ -152,6 +199,7 @@ document.addEventListener('DOMContentLoaded', function() {
         ],
         title=f'Data set "{data_set.name}"',
         js_files=[flask.url_for('mara_schema.static', filename='data-set-sql-query.js')],
+        css_files=[flask.url_for('mara_schema.static', filename='mara-schema.css')],
     )
 
 

--- a/mara_schema/ui/views.py
+++ b/mara_schema/ui/views.py
@@ -96,8 +96,11 @@ def data_set_page(id: str) -> response.Response:
                 ]])
             for prefixed_name, attribute in attributes.items():
                 rows.append(_.tr[_.td[escape(prefixed_name)],
-                                 _.td[_.i[escape(attribute.description)]],
-                                 _.td[_.tt[escape(f'{path[-1].target_entity.table_name + "." if path else ""}{attribute.column_name}')]]])
+                                 _.td[[_.i[escape(attribute.description)]] +
+                                      ([' (', _.a(href=attribute.more_url)['more...'], ')']
+                                       if attribute.more_url else [])],
+                                 _.td[_.tt[escape(
+                                     f'{path[-1].target_entity.table_name + "." if path else ""}{attribute.column_name}')]]])
         return rows
 
     return response.Response(
@@ -116,7 +119,9 @@ def data_set_page(id: str) -> response.Response:
                         ['Name', 'Description', 'Computation'],
                         [[_.tr[
                               _.td[escape(metric.name)],
-                              _.td[_.i[escape(metric.description)]],
+                              _.td[[_.i[escape(metric.description)]] +
+                                   ([' (', _.a(href=metric.more_url)['more...'], ')'] if metric.more_url else [])
+                                   ],
                               _.td[_.code[escape(metric.display_formula())]]
                           ] for metric in data_set.metrics.values()]]),
                 ]),

--- a/mara_schema/ui/views.py
+++ b/mara_schema/ui/views.py
@@ -27,7 +27,7 @@ def schema_navigation_entry() -> navigation.NavigationEntry:
         A mara NavigationEntry object.
 
     """
-    from ..config import data_sets
+    from .. import config
 
     return navigation.NavigationEntry(
         label='Data sets', icon='book',
@@ -38,14 +38,14 @@ def schema_navigation_entry() -> navigation.NavigationEntry:
                                                description=data_set.entity.description,
                                                uri_fn=lambda data_set=data_set: flask.url_for(
                                                    'mara_schema.data_set_page', id=data_set.id()))
-                    for data_set in data_sets()])
+                    for data_set in config.data_sets()])
 
 
 @blueprint.route('')
 @acl.require_permission(acl_resource_schema)
 def index_page() -> response.Response:
     """Renders the overview page"""
-    from ..config import data_sets
+    from .. import config
 
     return response.Response(
 
@@ -61,7 +61,7 @@ def index_page() -> response.Response:
                                                       id=data_set.id()))[
                         escape(data_set.name)]],
                           _.td[_.i[escape(data_set.entity.description)]],
-                     ] for data_set in data_sets()]),
+                     ] for data_set in config.data_sets()]),
             )],
         title='Data sets documentation',
         css_files=[flask.url_for('mara_schema.static', filename='schema.css')]
@@ -72,9 +72,9 @@ def index_page() -> response.Response:
 @acl.require_permission(acl_resource_schema)
 def data_set_page(id: str) -> response.Response:
     """Renders the pages for individual data sets"""
-    from ..config import data_sets
+    from .. import config
 
-    data_set = next((data_set for data_set in data_sets() if data_set.id() == id), None)
+    data_set = next((data_set for data_set in config.data_sets() if data_set.id() == id), None)
     if not data_set:
         flask.flash(f'Could not find data set "{id}"', category='warning')
         return flask.redirect(flask.url_for('mara_schema.index_page'))
@@ -158,11 +158,11 @@ document.addEventListener('DOMContentLoaded', function() {
 @blueprint.route('/<id>/_data_set_sql_query', defaults={'params': ''})
 @blueprint.route('/<id>/_data_set_sql_query/<path:params>')
 def data_set_sql_query(id: str, params: [str]) -> response.Response:
-    from ..config import data_sets
+    from .. import config
     from ..sql_generation import data_set_sql_query
 
     params = set(params.split('/'))
-    data_set = next((data_set for data_set in data_sets() if data_set.id() == id), None)
+    data_set = next((data_set for data_set in config.data_sets() if data_set.id() == id), None)
     if not data_set:
         return f'Could not find data set "{id}"'
 
@@ -189,10 +189,10 @@ def overview_graph() -> str:
 @acl.require_permission(acl_resource_schema)
 def data_set_graph(id: str) -> str:
     """Renders a graph with all the linked entities of an individual data sets"""
-    from ..config import data_sets
+    from .. import config
     from .graph import data_set_graph
 
-    data_set = next((data_set for data_set in data_sets() if data_set.id() == id), None)
+    data_set = next((data_set for data_set in config.data_sets() if data_set.id() == id), None)
     if not data_set:
         return f'Could not find data set "{id}"'
 
@@ -203,10 +203,10 @@ def data_set_graph(id: str) -> str:
 @acl.require_permission(acl_resource_schema)
 def metrics_graph(id: str) -> str:
     """Renders a visualization of all composed metrics of a data set"""
-    from ..config import data_sets
+    from .. import config
     from .graph import metrics_graph
 
-    data_set = next((data_set for data_set in data_sets() if data_set.id() == id), None)
+    data_set = next((data_set for data_set in config.data_sets() if data_set.id() == id), None)
     if not data_set:
         return f'Could not find data set "{id}"'
 


### PR DESCRIPTION
* Adds a 'more_url' to metrics and attributes and displays this as a `(_more..._)` to the end of the description.
* Changes some `from ..config import xxx` to `from .. import config` and `config.xxx()`to not break in case the patching happens later (probably unnecessary, as the imports all happened in a function, but better not put this pattern anywhere in as moving it to the module level)
* Adds an anchor to all metrics and attributes so that once can link to specific metrics/attributes -> WIP

The below CSS makes the linked to entry appear below the header. It works in Chrome, Firefox, and Edge. It doesn't work in Safari (and for sure not in IE :-)).

![image](https://user-images.githubusercontent.com/890156/105707662-942e1f00-5f13-11eb-8d60-036f29a98051.png)

(there is a hover on the second 'P' and the cursor turns into a hand there)