### PR TITLE
cast 0.0 to double precision

### DIFF
--- a/mara_schema/sql_generation.py
+++ b/mara_schema/sql_generation.py
@@ -138,7 +138,7 @@ def data_set_sql_query(data_set: DataSet,
         else:
             if '/' in metric.formula_template:  # avoid divisions by 0
                 return metric.formula_template.format(
-                    *[f'(NULLIF({sql_formula(metric)} :: DOUBLE PRECISION, 0.0))' for metric in metric.parent_metrics])
+                    *[f'(NULLIF({sql_formula(metric)}, 0.0 :: DOUBLE PRECISION))' for metric in metric.parent_metrics])
 
             else:  # render metric template
                 return metric.formula_template.format(

--- a/mara_schema/sql_generation.py
+++ b/mara_schema/sql_generation.py
@@ -110,7 +110,7 @@ def data_set_sql_query(data_set: DataSet,
         else:
             if '/' in metric.formula_template:  # avoid divisions by 0
                 return metric.formula_template.format(
-                    *[f'(NULLIF({sql_formula(metric)}, 0.0))' for metric in metric.parent_metrics])
+                    *[f'(NULLIF({sql_formula(metric)} :: DOUBLE PRECISION, 0.0))' for metric in metric.parent_metrics])
 
             else:  # render metric template
                 return metric.formula_template.format(


### PR DESCRIPTION
BigQuery doesn't support more than 38 decimal digits of precision; casting to a float circumvents that problem in divisions, especially when dealing with the scale. 
An alternative solution could be to allow user input for desired number decimal points, or allowing inbuilt rounding for divisions, though that would require an extension of `add_composed_metric`.