### PR TITLE
Add parameter star_schema_transitive_fks

### DIFF
--- a/mara_schema/sql_generation.py
+++ b/mara_schema/sql_generation.py
@@ -78,8 +78,6 @@ def data_set_sql_query(data_set: DataSet,
         # Add columns for all attributes of all transitively linked entities
         if transitive:
             for name, attribute in attributes.items():
-                print(name)
-                print(attribute)
                 if attribute.personal_data and not personal_data:
                     continue
                 if attribute.high_cardinality and not high_cardinality_attributes:

--- a/mara_schema/sql_generation.py
+++ b/mara_schema/sql_generation.py
@@ -138,7 +138,7 @@ def data_set_sql_query(data_set: DataSet,
         else:
             if '/' in metric.formula_template:  # avoid divisions by 0
                 return metric.formula_template.format(
-                    *[f'(NULLIF({sql_formula(metric)} :: DOUBLE PRECISION, 0.0))' for metric in metric.parent_metrics])
+                    *[f'(NULLIF({sql_formula(metric)}, 0.0))' for metric in metric.parent_metrics])
 
             else:  # render metric template
                 return metric.formula_template.format(

--- a/mara_schema/sql_generation.py
+++ b/mara_schema/sql_generation.py
@@ -110,7 +110,7 @@ def data_set_sql_query(data_set: DataSet,
         else:
             if '/' in metric.formula_template:  # avoid divisions by 0
                 return metric.formula_template.format(
-                    *[f'(NULLIF({sql_formula(metric)}, 0.0))' for metric in metric.parent_metrics])
+                    *[f'(NULLIF({sql_formula(metric)} :: DOUBLE PRECISION, 0.0))' for metric in metric.parent_metrics])
 
             else:  # render metric template
                 return metric.formula_template.format(

--- a/mara_schema/sql_generation.py
+++ b/mara_schema/sql_generation.py
@@ -75,7 +75,7 @@ def data_set_sql_query(data_set: DataSet,
                               if human_readable_columns else table_alias_for_path(path) + '_fk'),
                 cast_to_text=False, first=first)
 
-        # Add columns for all attributes
+        # Add columns for all attributes of all transitively linked entities
         if transitive:
             for name, attribute in attributes.items():
                 print(name)
@@ -105,6 +105,7 @@ def data_set_sql_query(data_set: DataSet,
                                               column_alias=column_alias,
                                               cast_to_text=attribute.type == Type.ENUM, first=first,
                                               custom_column_expression=custom_column_expression)
+        # Only add foreign key columns of linked entities
         elif transitive is False and path:
             first = add_column_definition(
                 table_alias=table_alias_for_path(path[:-1]) if len(path) > 1 else entity_table_alias,

--- a/mara_schema/ui/views.py
+++ b/mara_schema/ui/views.py
@@ -135,6 +135,7 @@ def data_set_page(id: str) -> response.Response:
                                   'human readable columns',
                                   'pre-computed metrics',
                                   'star schema',
+                                  'star_schema_transitive_fks',
                                   'personal data',
                                   'high cardinality attributes',
                               ]]],
@@ -166,7 +167,8 @@ def data_set_sql_query(id: str, params: [str]) -> response.Response:
                              human_readable_columns='human readable columns' in params,
                              personal_data='personal data' in params,
                              high_cardinality_attributes='high cardinality attributes' in params,
-                             star_schema='star schema' in params)
+                             star_schema='star schema' in params,
+                             star_schema_transitive_fks='star_schema_transitive_fks' in params)
     return str(_.div[html.highlight_syntax(sql, 'sql')])
 
 


### PR DESCRIPTION
(This is a branch on a branch, as we're currently using the branch this is built on in production.)

Adds the option for tables to have non-transitive connections to other entities, i.e. only keeping the respective foreign keys instead of flattening the linked entities. 